### PR TITLE
UHD Fixes and uspfs -> usbfs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,8 +153,8 @@ set(GRC_BLOCKS_DIR      ${GR_PKG_DATA_DIR}/grc/blocks)
 ########################################################################
 # Find build dependencies
 ########################################################################
-set(UHD_USE_STATIC_LIBS True)
-set(GR_REQUIRED_COMPONENTS RUNTIME BLOCKS)
+set(UHD_USE_STATIC_LIBS False)
+set(GR_REQUIRED_COMPONENTS RUNTIME BLOCKS PMT)
 find_package(Gnuradio 3.7.3 REQUIRED)
 find_package(GnuradioIQBalance)
 find_package(UHD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,10 @@ MESSAGE(STATUS "Configuring Boost C++ Libraries...")
 
 # Although not required on my system, some users have linking issues without
 SET(BOOST_REQUIRED_COMPONENTS
+    exception
     thread
     system
+    atomic
 )
 
 if(UNIX AND NOT BOOST_ROOT AND EXISTS "/usr/lib64")
@@ -147,7 +149,7 @@ set(GRC_BLOCKS_DIR      ${GR_PKG_DATA_DIR}/grc/blocks)
 ########################################################################
 # Find build dependencies
 ########################################################################
-set(GR_REQUIRED_COMPONENTS RUNTIME PMT BLOCKS)
+set(GR_REQUIRED_COMPONENTS RUNTIME BLOCKS)
 find_package(Gnuradio 3.7.3 REQUIRED)
 find_package(GnuradioIQBalance)
 find_package(UHD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,8 +100,12 @@ MESSAGE(STATUS "Configuring Boost C++ Libraries...")
 # Although not required on my system, some users have linking issues without
 SET(BOOST_REQUIRED_COMPONENTS
     exception
-    thread
+    date_time
+    program_options
+    regex
+    filesystem
     system
+    thread
     atomic
 )
 
@@ -149,6 +153,7 @@ set(GRC_BLOCKS_DIR      ${GR_PKG_DATA_DIR}/grc/blocks)
 ########################################################################
 # Find build dependencies
 ########################################################################
+set(UHD_USE_STATIC_LIBS True)
 set(GR_REQUIRED_COMPONENTS RUNTIME BLOCKS)
 find_package(Gnuradio 3.7.3 REQUIRED)
 find_package(GnuradioIQBalance)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -43,12 +43,6 @@ GR_OSMOSDR_APPEND_SRCS(
     time_spec.cc
 )
 
-GR_OSMOSDR_APPEND_LIBS(
-    ${Boost_LIBRARIES}
-    ${GNURADIO_ALL_LIBRARIES}
-    log
-)
-
 if(ANDROID)
 GR_OSMOSDR_APPEND_LIBS(
     log
@@ -244,6 +238,17 @@ IF(MSVC)
 
     GR_OSMOSDR_APPEND_SRCS(${CMAKE_CURRENT_BINARY_DIR}/gnuradio-osmosdr.rc)
 ENDIF(MSVC)
+
+
+
+
+GR_OSMOSDR_APPEND_LIBS(
+    ${GNURADIO_ALL_LIBRARIES}
+    ${Boost_LIBRARIES}
+)
+
+
+
 
 ########################################################################
 # Setup libgnuradio-osmosdr library

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,7 +46,14 @@ GR_OSMOSDR_APPEND_SRCS(
 GR_OSMOSDR_APPEND_LIBS(
     ${Boost_LIBRARIES}
     ${GNURADIO_ALL_LIBRARIES}
+    log
 )
+
+if(ANDROID)
+GR_OSMOSDR_APPEND_LIBS(
+    log
+)
+endif(ANDROID)
 
 ########################################################################
 # Setup defines for high resolution timing
@@ -245,3 +252,19 @@ ADD_LIBRARY(gnuradio-osmosdr SHARED ${gr_osmosdr_srcs})
 TARGET_LINK_LIBRARIES(gnuradio-osmosdr ${gr_osmosdr_libs})
 SET_TARGET_PROPERTIES(gnuradio-osmosdr PROPERTIES DEFINE_SYMBOL "gnuradio_osmosdr_EXPORTS")
 GR_LIBRARY_FOO(gnuradio-osmosdr)
+
+
+
+########################################################################
+# Static library build
+########################################################################
+add_library(gnuradio-osmosdr_static STATIC ${gr_osmosdr_srcs})
+
+if(NOT WIN32)
+  set_target_properties(gnuradio-osmosdr_static
+    PROPERTIES OUTPUT_NAME gnuradio-osmosdr)
+endif(NOT WIN32)
+
+install(TARGETS gnuradio-osmosdr_static
+  ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT "gnuradio_osmosdr_devel"   # .lib file
+  )

--- a/lib/device.cc
+++ b/lib/device.cc
@@ -78,11 +78,34 @@
 
 using namespace osmosdr;
 
-static const std::string args_delim = " ";
-static const std::string pairs_delim = ",";
-static const std::string pair_delim = "=";
+static const std::string
+get_args_delim()
+{
+  static const std::string args_delim = " ";
+  return args_delim;
+}
 
-static boost::mutex _device_mutex;
+static const std::string
+get_pairs_delim()
+{
+  static const std::string pairs_delim = ",";
+  return pairs_delim;
+}
+
+static const std::string
+get_pair_delim()
+{
+  static const std::string pair_delim = "=";
+  return pair_delim;
+}
+
+static boost::mutex*
+get_device_mutex()
+{
+  static boost::mutex _device_mutex;
+  return &_device_mutex;
+}
+
 
 device_t::device_t(const std::string &args)
 {
@@ -112,16 +135,16 @@ std::string device_t::to_string(void) const
     std::string value = entry.second;
     if (value.find(" ") != std::string::npos)
       value = "'" + value + "'";
-    ss << ((count++) ? pairs_delim : "") + entry.first;
+    ss << ((count++) ? get_pairs_delim() : "") + entry.first;
     if (value.length())
-      ss << pair_delim + value;
+      ss << get_pair_delim() + value;
   }
   return ss.str();
 }
 
 devices_t device::find(const device_t &hint)
 {
-  boost::mutex::scoped_lock lock(_device_mutex);
+  boost::mutex::scoped_lock lock(*get_device_mutex());
 
   bool fake = true;
 

--- a/lib/rtl/rtl_source_c.cc
+++ b/lib/rtl/rtl_source_c.cc
@@ -43,6 +43,13 @@
 
 #include "arg_helpers.h"
 
+
+
+#include <android/log.h>
+#define LOGD(name, msg) __android_log_print(ANDROID_LOG_DEBUG, name, msg)
+
+
+
 using namespace boost::assign;
 
 #define BUF_LEN  (16 * 32 * 512) /* must be multiple of 512 */
@@ -98,45 +105,53 @@ rtl_source_c::rtl_source_c (const std::string &args)
   char product[256];
   char serial[256];
 
+  std::stringstream sstr;
+
   dict_t dict = params_to_dict(args);
 
-  if (dict.count("rtl")) {
-    std::string value = dict["rtl"];
+  //if (dict.count("rtl")) {
+  //  std::string value = dict["rtl"];
+  //
+  //  if ( (index = rtlsdr_get_index_by_serial( value.c_str() )) >= 0 ) {
+  //    dev_index = index; /* use the resolved index value */
+  //  } else { /* use the numeric value of the argument */
+  //    if ( value.length() ) {
+  //      try {
+  //        dev_index = boost::lexical_cast< unsigned int >( value );
+  //      } catch ( std::exception &ex ) {
+  //        throw std::runtime_error(
+  //              "Failed to use '" + value + "' as index: " + ex.what());
+  //      }
+  //    }
+  //  }
+  //}
 
-    if ( (index = rtlsdr_get_index_by_serial( value.c_str() )) >= 0 ) {
-      dev_index = index; /* use the resolved index value */
-    } else { /* use the numeric value of the argument */
-      if ( value.length() ) {
-        try {
-          dev_index = boost::lexical_cast< unsigned int >( value );
-        } catch ( std::exception &ex ) {
-          throw std::runtime_error(
-                "Failed to use '" + value + "' as index: " + ex.what());
-        }
-      }
-    }
-  }
+  dev_index = 0;
 
-  if ( dev_index >= rtlsdr_get_device_count() )
-    throw std::runtime_error("Wrong rtlsdr device index given.");
+  //if ( dev_index >= rtlsdr_get_device_count() )
+  //  throw std::runtime_error("Wrong rtlsdr device index given.");
 
-  std::cerr << "Using device #" << dev_index;
 
-  memset(manufact, 0, sizeof(manufact));
-  memset(product, 0, sizeof(product));
-  memset(serial, 0, sizeof(serial));
-  if ( !rtlsdr_get_device_usb_strings( dev_index, manufact, product, serial ) ) {
-    if (strlen(manufact))
-      std::cerr << " " << manufact;
-    if (strlen(product))
-      std::cerr << " " << product;
-    if (strlen(serial))
-      std::cerr << " SN: " << serial;
-  } else {
-    std::cerr << " " << rtlsdr_get_device_name(dev_index);
-  }
+  sstr.clear();
+  sstr << "Using device #" << dev_index;
 
-  std::cerr << std::endl;
+  //memset(manufact, 0, sizeof(manufact));
+  //memset(product, 0, sizeof(product));
+  //memset(serial, 0, sizeof(serial));
+  //if ( !rtlsdr_get_device_usb_strings( dev_index, manufact, product, serial ) ) {
+  //  if (strlen(manufact))
+  //    sstr << " " << manufact;
+  //  if (strlen(product))
+  //    sstr << " " << product;
+  //  if (strlen(serial))
+  //    sstr << " SN: " << serial;
+  //} else {
+  //  sstr << " " << rtlsdr_get_device_name(dev_index);
+  //}
+
+  sstr << std::endl;
+  LOGD("omsosdr::rtl", sstr.str().c_str());
+  sstr.clear();
 
   if (dict.count("rtl_xtal"))
     rtl_freq = (unsigned int)boost::lexical_cast< double >( dict["rtl_xtal"] );

--- a/lib/rtl/rtl_source_c.cc
+++ b/lib/rtl/rtl_source_c.cc
@@ -105,6 +105,11 @@ rtl_source_c::rtl_source_c (const std::string &args)
   char product[256];
   char serial[256];
 
+#if ANDROID
+  int fd;
+  std::string uspfs_path;
+#endif
+
   std::stringstream sstr;
 
   dict_t dict = params_to_dict(args);
@@ -173,6 +178,14 @@ rtl_source_c::rtl_source_c (const std::string &args)
   if (dict.count("buflen"))
     _buf_len = boost::lexical_cast< unsigned int >( dict["buflen"] );
 
+#if ANDROID
+  if (dict.count("fd"))
+    fd = boost::lexical_cast< unsigned int >( dict["fd"] );
+
+  if (dict.count("uspfs_path"))
+    uspfs_path = boost::lexical_cast< std::string >( dict["uspfs_path"] );
+#endif
+
   if (0 == _buf_num)
     _buf_num = BUF_NUM;
 
@@ -198,7 +211,13 @@ rtl_source_c::rtl_source_c (const std::string &args)
   }
 
   _dev = NULL;
+
+#if ANDROID
+  ret = rtlsdr_open( &_dev, dev_index, fd, uspfs_path.c_str() );
+#else
   ret = rtlsdr_open( &_dev, dev_index );
+#endif
+
   if (ret < 0)
     throw std::runtime_error("Failed to open rtlsdr device.");
 

--- a/lib/rtl/rtl_source_c.cc
+++ b/lib/rtl/rtl_source_c.cc
@@ -106,8 +106,8 @@ rtl_source_c::rtl_source_c (const std::string &args)
   char serial[256];
 
 #if ANDROID
-  int fd;
-  std::string uspfs_path;
+  int fd = 0;
+  std::string uspfs_path = "";
 #endif
 
   std::stringstream sstr;
@@ -180,7 +180,7 @@ rtl_source_c::rtl_source_c (const std::string &args)
 
 #if ANDROID
   if (dict.count("fd"))
-    fd = boost::lexical_cast< unsigned int >( dict["fd"] );
+    fd = boost::lexical_cast< int >( dict["fd"] );
 
   if (dict.count("uspfs_path"))
     uspfs_path = boost::lexical_cast< std::string >( dict["uspfs_path"] );
@@ -213,6 +213,9 @@ rtl_source_c::rtl_source_c (const std::string &args)
   _dev = NULL;
 
 #if ANDROID
+  sstr.clear();
+  sstr <<  "Calling rtlsdr_open with fd: " << fd << "  and path: " << (uspfs_path.c_str()) << std::endl;
+  LOGD("omsosdr::rtl", sstr.str().c_str());
   ret = rtlsdr_open( &_dev, dev_index, fd, uspfs_path.c_str() );
 #else
   ret = rtlsdr_open( &_dev, dev_index );

--- a/lib/rtl/rtl_source_c.cc
+++ b/lib/rtl/rtl_source_c.cc
@@ -107,7 +107,7 @@ rtl_source_c::rtl_source_c (const std::string &args)
 
 #if ANDROID
   int fd = 0;
-  std::string uspfs_path = "";
+  std::string usbfs_path = "";
 #endif
 
   std::stringstream sstr;
@@ -182,8 +182,8 @@ rtl_source_c::rtl_source_c (const std::string &args)
   if (dict.count("fd"))
     fd = boost::lexical_cast< int >( dict["fd"] );
 
-  if (dict.count("uspfs_path"))
-    uspfs_path = boost::lexical_cast< std::string >( dict["uspfs_path"] );
+  if (dict.count("usbfs_path"))
+    usbfs_path = boost::lexical_cast< std::string >( dict["usbfs_path"] );
 #endif
 
   if (0 == _buf_num)
@@ -214,9 +214,9 @@ rtl_source_c::rtl_source_c (const std::string &args)
 
 #if ANDROID
   sstr.clear();
-  sstr <<  "Calling rtlsdr_open with fd: " << fd << "  and path: " << (uspfs_path.c_str()) << std::endl;
+  sstr <<  "Calling rtlsdr_open with fd: " << fd << "  and path: " << (usbfs_path.c_str()) << std::endl;
   LOGD("omsosdr::rtl", sstr.str().c_str());
-  ret = rtlsdr_open( &_dev, dev_index, fd, uspfs_path.c_str() );
+  ret = rtlsdr_open( &_dev, dev_index, fd, usbfs_path.c_str() );
 #else
   ret = rtlsdr_open( &_dev, dev_index );
 #endif

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -258,10 +258,8 @@ source_impl::source_impl( const std::string &args )
 
 #ifdef ENABLE_RTL
     if ( dict.count("rtl") ) {
-      LOGD("omsosdr::rtl", "CALLING make_rtl_source_c");
-      rtl_source_c_sptr src = make_rtl_source_c( arg , fd, path);
+      rtl_source_c_sptr src = make_rtl_source_c( arg );
       block = src; iface = src.get();
-      LOGD("omsosdr::rtl", "CALLED make_rtl_source_c");
     }
 #endif
 

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -79,13 +79,16 @@
 #include "arg_helpers.h"
 #include "source_impl.h"
 
-#include <android/log.h>
-
 /* This avoids throws in ctor of gr::hier_block2, as gnuradio is unable to deal
  with this behavior in a clean way. The GR maintainer Rondeau has been informed. */
 #define WORKAROUND_GR_HIER_BLOCK2_BUG
 
+
+// Support for android logging
+#ifdef ANDROID
+#include <android/log.h>
 #define LOGD(name, msg) __android_log_print(ANDROID_LOG_DEBUG, name, msg)
+#endif
 
 
 /*
@@ -155,7 +158,7 @@ source_impl::source_impl( const std::string &args )
   BOOST_FOREACH(std::string dev_type, dev_types)
     sstr << dev_type << " ";
   sstr << std::endl;
-  LOGD("omsosdr::rtl", sstr.str().c_str());
+  LOGD("omsosdr", sstr.str().c_str());
 
 #ifdef ENABLE_RFSPACE
   dev_types.push_back("sdr-iq"); /* additional aliases for rfspace backend */
@@ -226,11 +229,11 @@ source_impl::source_impl( const std::string &args )
 
   BOOST_FOREACH(std::string arg, arg_list) {
 
+    LOGD("omsosdr", boost::str(boost::format("arg: %1%") % arg).c_str());
     dict_t dict = params_to_dict(arg);
 
-//    std::cerr << std::endl;
-//    BOOST_FOREACH( dict_t::value_type &entry, dict )
-//      std::cerr << "'" << entry.first << "' = '" << entry.second << "'" << std::endl;
+    BOOST_FOREACH( dict_t::value_type &entry, dict )
+      LOGD("omsosdr", boost::str(boost::format(" ->   %1% : %2%") % entry.first % entry.second).c_str());
 
     source_iface *iface = NULL;
     gr::basic_block_sptr block;
@@ -258,6 +261,7 @@ source_impl::source_impl( const std::string &args )
 
 #ifdef ENABLE_RTL
     if ( dict.count("rtl") ) {
+      LOGD("omsosdr", "selected device: rtl");
       rtl_source_c_sptr src = make_rtl_source_c( arg );
       block = src; iface = src.get();
     }
@@ -272,6 +276,7 @@ source_impl::source_impl( const std::string &args )
 
 #ifdef ENABLE_UHD
     if ( dict.count("uhd") ) {
+      LOGD("omsosdr", "selected device: uhd");
       uhd_source_c_sptr src = make_uhd_source_c( arg );
       block = src; iface = src.get();
     }

--- a/lib/source_impl.cc
+++ b/lib/source_impl.cc
@@ -79,9 +79,14 @@
 #include "arg_helpers.h"
 #include "source_impl.h"
 
+#include <android/log.h>
+
 /* This avoids throws in ctor of gr::hier_block2, as gnuradio is unable to deal
  with this behavior in a clean way. The GR maintainer Rondeau has been informed. */
 #define WORKAROUND_GR_HIER_BLOCK2_BUG
+
+#define LOGD(name, msg) __android_log_print(ANDROID_LOG_DEBUG, name, msg)
+
 
 /*
  * Create a new instance of source_impl and return
@@ -142,13 +147,15 @@ source_impl::source_impl( const std::string &args )
 #ifdef ENABLE_AIRSPY
   dev_types.push_back("airspy");
 #endif
-  std::cerr << "gr-osmosdr "
+  std::stringstream sstr;
+  sstr << "gr-osmosdr "
             << GR_OSMOSDR_VERSION << " (" << GR_OSMOSDR_LIBVER << ") "
             << "gnuradio " << gr::version() << std::endl;
-  std::cerr << "built-in source types: ";
+  sstr << "built-in source types: ";
   BOOST_FOREACH(std::string dev_type, dev_types)
-    std::cerr << dev_type << " ";
-  std::cerr << std::endl << std::flush;
+    sstr << dev_type << " ";
+  sstr << std::endl;
+  LOGD("omsosdr::rtl", sstr.str().c_str());
 
 #ifdef ENABLE_RFSPACE
   dev_types.push_back("sdr-iq"); /* additional aliases for rfspace backend */
@@ -251,8 +258,10 @@ source_impl::source_impl( const std::string &args )
 
 #ifdef ENABLE_RTL
     if ( dict.count("rtl") ) {
-      rtl_source_c_sptr src = make_rtl_source_c( arg );
+      LOGD("omsosdr::rtl", "CALLING make_rtl_source_c");
+      rtl_source_c_sptr src = make_rtl_source_c( arg , fd, path);
       block = src; iface = src.get();
+      LOGD("omsosdr::rtl", "CALLED make_rtl_source_c");
     }
 #endif
 
@@ -814,99 +823,106 @@ osmosdr::freq_range_t source_impl::get_bandwidth_range( size_t chan )
 
 void source_impl::set_time_source(const std::string &source, const size_t mboard)
 {
-  if (mboard != osmosdr::ALL_MBOARDS){
-      _devs.at(mboard)->set_time_source( source );
-      return;
-  }
-
-  for (size_t m = 0; m < _devs.size(); m++){ /* propagate ALL_MBOARDS */
-      _devs.at(m)->set_time_source( source, osmosdr::ALL_MBOARDS );
-  }
+  //if (mboard != osmosdr::ALL_MBOARDS){
+  //    _devs.at(mboard)->set_time_source( source );
+  //    return;
+  //}
+  //
+  //for (size_t m = 0; m < _devs.size(); m++){ /* propagate ALL_MBOARDS */
+  //    _devs.at(m)->set_time_source( source, osmosdr::ALL_MBOARDS );
+  //}
 }
 
 std::string source_impl::get_time_source(const size_t mboard)
 {
-  return _devs.at(mboard)->get_time_source( mboard );
+  //return _devs.at(mboard)->get_time_source( mboard );
+  return "";
 }
 
 std::vector<std::string> source_impl::get_time_sources(const size_t mboard)
 {
-  return _devs.at(mboard)->get_time_sources( mboard );
+  //return _devs.at(mboard)->get_time_sources( mboard );
+  return std::vector<std::string>();
 }
 
 void source_impl::set_clock_source(const std::string &source, const size_t mboard)
 {
-  if (mboard != osmosdr::ALL_MBOARDS){
-      _devs.at(mboard)->set_clock_source( source );
-      return;
-  }
-
-  for (size_t m = 0; m < _devs.size(); m++){ /* propagate ALL_MBOARDS */
-      _devs.at(m)->set_clock_source( source, osmosdr::ALL_MBOARDS );
-  }
+  //if (mboard != osmosdr::ALL_MBOARDS){
+  //    _devs.at(mboard)->set_clock_source( source );
+  //    return;
+  //}
+  //
+  //for (size_t m = 0; m < _devs.size(); m++){ /* propagate ALL_MBOARDS */
+  //    _devs.at(m)->set_clock_source( source, osmosdr::ALL_MBOARDS );
+  //}
 }
 
 std::string source_impl::get_clock_source(const size_t mboard)
 {
-  return _devs.at(mboard)->get_clock_source( mboard );
+  //return _devs.at(mboard)->get_clock_source( mboard );
+  return "";
 }
 
 std::vector<std::string> source_impl::get_clock_sources(const size_t mboard)
 {
-  return _devs.at(mboard)->get_clock_sources( mboard );
+  //return _devs.at(mboard)->get_clock_sources( mboard );
+  return std::vector<std::string>();
 }
 
 double source_impl::get_clock_rate(size_t mboard)
 {
-  return _devs.at(mboard)->get_clock_rate( mboard );
+  //return _devs.at(mboard)->get_clock_rate( mboard );
+  return 0;
 }
 
 void source_impl::set_clock_rate(double rate, size_t mboard)
 {
-  if (mboard != osmosdr::ALL_MBOARDS){
-      _devs.at(mboard)->set_clock_rate( rate );
-      return;
-  }
-
-  for (size_t m = 0; m < _devs.size(); m++){ /* propagate ALL_MBOARDS */
-      _devs.at(m)->set_clock_rate( rate, osmosdr::ALL_MBOARDS );
-  }
+  //if (mboard != osmosdr::ALL_MBOARDS){
+  //  _devs.at(mboard)->set_clock_rate( rate );
+  //    return;
+  //}
+  //
+  //for (size_t m = 0; m < _devs.size(); m++){ /* propagate ALL_MBOARDS */
+  //    _devs.at(m)->set_clock_rate( rate, osmosdr::ALL_MBOARDS );
+  //}
 }
 
 osmosdr::time_spec_t source_impl::get_time_now(size_t mboard)
 {
-  return _devs.at(mboard)->get_time_now( mboard );
+  //return _devs.at(mboard)->get_time_now( mboard );
+  return osmosdr::time_spec_t(0,0);
 }
 
 osmosdr::time_spec_t source_impl::get_time_last_pps(size_t mboard)
 {
-  return _devs.at(mboard)->get_time_last_pps( mboard );
+  //return _devs.at(mboard)->get_time_last_pps( mboard );
+  return osmosdr::time_spec_t(0,0);
 }
 
 void source_impl::set_time_now(const osmosdr::time_spec_t &time_spec, size_t mboard)
 {
-  if (mboard != osmosdr::ALL_MBOARDS){
-      _devs.at(mboard)->set_time_now( time_spec );
-      return;
-  }
-
-  for (size_t m = 0; m < _devs.size(); m++){ /* propagate ALL_MBOARDS */
-      _devs.at(m)->set_time_now( time_spec, osmosdr::ALL_MBOARDS );
-  }
+  //if (mboard != osmosdr::ALL_MBOARDS){
+  //    _devs.at(mboard)->set_time_now( time_spec );
+  //    return;
+  //}
+  //
+  //for (size_t m = 0; m < _devs.size(); m++){ /* propagate ALL_MBOARDS */
+  //    _devs.at(m)->set_time_now( time_spec, osmosdr::ALL_MBOARDS );
+  //}
 }
 
 void source_impl::set_time_next_pps(const osmosdr::time_spec_t &time_spec)
 {
-  BOOST_FOREACH( source_iface *dev, _devs )
-  {
-    dev->set_time_next_pps( time_spec );
-  }
+  //BOOST_FOREACH( source_iface *dev, _devs )
+  //{
+  //  dev->set_time_next_pps( time_spec );
+  //}
 }
 
 void source_impl::set_time_unknown_pps(const osmosdr::time_spec_t &time_spec)
 {
-  BOOST_FOREACH( source_iface *dev, _devs )
-  {
-    dev->set_time_unknown_pps( time_spec );
-  }
+  //BOOST_FOREACH( source_iface *dev, _devs )
+  //{
+  //  dev->set_time_unknown_pps( time_spec );
+  //}
 }

--- a/lib/uhd/uhd_source_c.cc
+++ b/lib/uhd/uhd_source_c.cc
@@ -99,7 +99,7 @@ uhd_source_c::uhd_source_c(const std::string &args) :
     arguments += entry.first + "=" + entry.second + ",";
   }
 
-  //arguments += "fd=21,uspfs_path_input=\"/dev/bus/usb\",";
+  //arguments += "fd=21,usbfs_path_input=\"/dev/bus/usb\",";
 
   LOGD("omsosdr::uhd_source_c",
        boost::str(boost::format("reformatted args: %1%")    \

--- a/lib/uhd/uhd_source_c.cc
+++ b/lib/uhd/uhd_source_c.cc
@@ -78,6 +78,11 @@ uhd_source_c::uhd_source_c(const std::string &args) :
   if (dict.count("lo_offset"))
     _lo_offset = boost::lexical_cast< double >( dict["lo_offset"] );
 
+  LOGD("omsosdr::uhd_source_c",
+       boost::str(boost::format("args: %1%")    \
+                  % args).c_str());
+
+
   std::string arguments; // rebuild argument string without internal arguments
   BOOST_FOREACH( dict_t::value_type &entry, dict )
   {
@@ -94,7 +99,11 @@ uhd_source_c::uhd_source_c(const std::string &args) :
     arguments += entry.first + "=" + entry.second + ",";
   }
 
-  arguments += "fd=21,uspfs_path_input=\"/dev/bus/usb\",";
+  //arguments += "fd=21,uspfs_path_input=\"/dev/bus/usb\",";
+
+  LOGD("omsosdr::uhd_source_c",
+       boost::str(boost::format("reformatted args: %1%")    \
+                  % arguments).c_str());
 
   stream_args.cpu_format = "fc32";
   stream_args.otw_format = "sc16";


### PR DESCRIPTION
Using UHD statically requires the --whole-archive switch to get devices detected, so I switched it to use shared libraries.  This works a bit easier on Android.
